### PR TITLE
Fix block highlight using wrong pos reference

### DIFF
--- a/src/main/java/net/blay09/mods/kleeslabs/KleeSlabs.java
+++ b/src/main/java/net/blay09/mods/kleeslabs/KleeSlabs.java
@@ -108,7 +108,7 @@ public class KleeSlabs {
                 double offsetY = player.lastTickPosY + (player.posY - player.lastTickPosY) * (double) event.getPartialTicks();
                 double offsetZ = player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * (double) event.getPartialTicks();
                 AxisAlignedBB halfAABB = new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 0.5, pos.getZ() + 1);
-                if (event.getTarget().hitVec.y - player.posY > 0.5) {
+                if (event.getTarget().hitVec.y - (double) pos.getY() > 0.5) {
                     halfAABB = halfAABB.offset(0, 0.5, 0);
                 }
                 RenderGlobal.drawSelectionBoundingBox(halfAABB.grow(0.002).offset(-offsetX, -offsetY, -offsetZ), 0f, 0f, 0f, 0.4f);


### PR DESCRIPTION
Fixes block highlight being incorrect when the player is at a different Y level to the targeted block. Screenshots of this issue can be seen below.

![below](https://i.imgur.com/5Nn89ZY.png)
![above](https://i.imgur.com/qQ5E49d.png)