### PR TITLE
Define common.disabledCompat as a list to stop failing validation

### DIFF
--- a/src/main/java/net/blay09/mods/kleeslabs/KleeSlabsConfig.java
+++ b/src/main/java/net/blay09/mods/kleeslabs/KleeSlabsConfig.java
@@ -28,7 +28,7 @@ public class KleeSlabsConfig {
             disabledCompat = builder
                     .comment("IDs of mods whose compatibility should be disabled.")
                     .translation("kleeslabs.config.disabledCompat")
-                    .define("disabledCompat", Collections.emptyList());
+                    .defineList("disabledCompat", Collections.emptyList(), o -> o instanceof String);
         }
     }
 


### PR DESCRIPTION
That is, "Incorrect key common.disabledCompat was corrected from [] to []"