### PR TITLE
1.18 Compatibillity fix for RefabricatedSlabs mod

### DIFF
--- a/shared/src/main/java/net/blay09/mods/kleeslabs/BlockBreakHandler.java
+++ b/shared/src/main/java/net/blay09/mods/kleeslabs/BlockBreakHandler.java
@@ -41,9 +41,19 @@ public class BlockBreakHandler {
             return;
         }
 
-        BlockState dropState = slabConverter.getSingleSlab(state, SlabType.BOTTOM);
+        SlabType hit;
+        SlabType stay;
+        if (hitVec != null && hitVec.y > 0.5f) {
+            hit = SlabType.TOP;
+            stay = SlabType.BOTTOM;
+        } else {
+            stay = SlabType.TOP;
+            hit = SlabType.BOTTOM;
+        }
+
+        BlockState dropState = slabConverter.getSingleSlab(event, hit);
         Level level = event.getLevel();
-        if (!level.isClientSide() && event.getPlayer().hasCorrectToolForDrops(event.getState()) && !event.getPlayer().getAbilities().instabuild) {
+        if (!level.isClientSide() && event.getPlayer().hasCorrectToolForDrops(dropState) && !event.getPlayer().getAbilities().instabuild) {
             Item slabItem = Item.byBlock(dropState.getBlock());
             if (slabItem != Items.AIR) {
                 ItemStack itemStack = new ItemStack(slabItem);
@@ -57,13 +67,7 @@ public class BlockBreakHandler {
             }
         }
 
-        BlockState newState;
-        if (hitVec != null && hitVec.y < 0.5f) {
-            newState = slabConverter.getSingleSlab(state, SlabType.TOP);
-        } else {
-            newState = slabConverter.getSingleSlab(state, SlabType.BOTTOM);
-        }
-
+        BlockState newState = slabConverter.getSingleSlab(event, stay);
         event.getLevel().setBlock(event.getPos(), newState, 1 | 2);
         event.setCanceled(true);
     }

--- a/shared/src/main/java/net/blay09/mods/kleeslabs/BlockBreakHandler.java
+++ b/shared/src/main/java/net/blay09/mods/kleeslabs/BlockBreakHandler.java
@@ -51,7 +51,7 @@ public class BlockBreakHandler {
             hit = SlabType.BOTTOM;
         }
 
-        BlockState dropState = slabConverter.getSingleSlab(event, hit);
+        BlockState dropState = slabConverter.getSingleSlab(event.getState(), event.getLevel(), event.getPos(), event.getPlayer(), hit);
         Level level = event.getLevel();
         if (!level.isClientSide() && event.getPlayer().hasCorrectToolForDrops(dropState) && !event.getPlayer().getAbilities().instabuild) {
             Item slabItem = Item.byBlock(dropState.getBlock());
@@ -67,7 +67,7 @@ public class BlockBreakHandler {
             }
         }
 
-        BlockState newState = slabConverter.getSingleSlab(event, stay);
+        BlockState newState = slabConverter.getSingleSlab(event.getState(), event.getLevel(), event.getPos(), event.getPlayer(), stay);
         event.getLevel().setBlock(event.getPos(), newState, 1 | 2);
         event.setCanceled(true);
     }

--- a/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SimpleSlabConverter.java
+++ b/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SimpleSlabConverter.java
@@ -1,5 +1,8 @@
 package net.blay09.mods.kleeslabs.converter;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -14,7 +17,7 @@ public class SimpleSlabConverter implements SlabConverter {
     }
 
     @Override
-    public BlockState getSingleSlab(BlockState state, SlabType slabType) {
+    public BlockState getSingleSlab(BlockState state, Level level, BlockPos pos, Player player, SlabType slabType) {
         return singleSlab.defaultBlockState().setValue(BlockStateProperties.SLAB_TYPE, slabType);
     }
 

--- a/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SlabConverter.java
+++ b/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SlabConverter.java
@@ -2,17 +2,14 @@
 
 package net.blay09.mods.kleeslabs.converter;
 
-import net.blay09.mods.balm.api.event.BreakBlockEvent;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.SlabType;
 
 public interface SlabConverter {
-
-    BlockState getSingleSlab(BlockState state, SlabType slabType);
-
-    default BlockState getSingleSlab(BreakBlockEvent event, SlabType slabType) {
-        return getSingleSlab(event.getState(), slabType);
-    }
+    BlockState getSingleSlab(BlockState state, Level level, BlockPos pos, Player player, SlabType slabType);
 
     default boolean isDoubleSlab(BlockState state) {
         return true;

--- a/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SlabConverter.java
+++ b/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SlabConverter.java
@@ -1,11 +1,18 @@
+
+
 package net.blay09.mods.kleeslabs.converter;
 
+import net.blay09.mods.balm.api.event.BreakBlockEvent;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.SlabType;
 
 public interface SlabConverter {
 
     BlockState getSingleSlab(BlockState state, SlabType slabType);
+
+    default BlockState getSingleSlab(BreakBlockEvent event, SlabType slabType) {
+        return getSingleSlab(event.getState(), slabType);
+    }
 
     default boolean isDoubleSlab(BlockState state) {
         return true;

--- a/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SmartSlabConverter.java
+++ b/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SmartSlabConverter.java
@@ -1,5 +1,8 @@
 package net.blay09.mods.kleeslabs.converter;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -15,7 +18,7 @@ public class SmartSlabConverter implements SlabConverter {
     }
 
     @Override
-    public BlockState getSingleSlab(BlockState state, SlabType slabType) {
+    public BlockState getSingleSlab(BlockState state, Level level, BlockPos pos, Player player, SlabType slabType) {
         BlockState newState = singleSlab.defaultBlockState();
         for (Property<?> property : state.getProperties()) {
             if (newState.getProperties().contains(property)) {

--- a/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SmarterSlabConverter.java
+++ b/shared/src/main/java/net/blay09/mods/kleeslabs/converter/SmarterSlabConverter.java
@@ -1,6 +1,9 @@
 package net.blay09.mods.kleeslabs.converter;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -17,7 +20,7 @@ public class SmarterSlabConverter implements SlabConverter {
     }
 
     @Override
-    public BlockState getSingleSlab(BlockState state, SlabType slabType) {
+    public BlockState getSingleSlab(BlockState state, Level level, BlockPos pos, Player player, SlabType slabType) {
         BlockState newState = slabBlock.defaultBlockState();
         for (Property<?> property : state.getProperties()) {
             if (property.getName().equals("half")) {


### PR DESCRIPTION
## Info
Compatibility fix for issue https://github.com/ModdingForBlockheads/KleeSlabs/issues/53 for RefabricatedSlabs mod

## Changes
SlabConverter
- Added a new method to the SlabConverter interface for compatibility fix

BlockBreakHandler
- Vector hit position calculated before asking for single slab state
- By doing so correct slab is used for block state property calculation
- Changed SlabConverter method calls to the new method